### PR TITLE
Constructor Deprecation Error in WP 4.3

### DIFF
--- a/includes/widget-area.php
+++ b/includes/widget-area.php
@@ -19,7 +19,7 @@ class Simple_Page_Sidebars_Widget_Area extends WP_Widget {
 		);
 
 		// Call the parent constructor.
-		$this->WP_Widget( 'area', __( 'Widget Area', 'simple-page-sidebars' ), $widget_ops );
+		parent::__construct( 'area', __( 'Widget Area', 'simple-page-sidebars' ), $widget_ops );
 	}
 
 	/**


### PR DESCRIPTION
I was testing this plugin in the upcoming WordPress 4.3 and I was getting a deprecation error thrown based on the usage of PHP4 constructor. More info can be found here: [https://gist.github.com/chriscct7/d7d077afb01011b1839d](https://gist.github.com/chriscct7/d7d077afb01011b1839d)

There may be more required edits to bring this plugin up to PHP5 standards BUT this simple and nonintrusive edit seems to have solved the problem for me. I am no longer receiving a deprecation error using this modified code.
